### PR TITLE
Vnitin x/insn num based tracing

### DIFF
--- a/include/dromajo_stf.h
+++ b/include/dromajo_stf.h
@@ -13,3 +13,4 @@ extern stf::STFWriter stf_writer;
 extern void stf_trace_element(RISCVMachine*,int hartid,int priv,
                               uint64_t last_pc,uint32_t insn);
 extern bool stf_trace_trigger(RISCVCPUState*,uint64_t PC,uint32_t insn);
+extern bool stf_trace_trigger_insn(RISCVCPUState *s,target_ulong PC, uint64_t insn_executed);

--- a/include/dromajo_template.h
+++ b/include/dromajo_template.h
@@ -1813,10 +1813,12 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles) {
     jump_insn:;
 
         if(s->machine->common.stf_trace) {
-            if(stf_trace_trigger(s,GET_PC(),insn)) {
-              s->pc = GET_PC();
-              return insn_executed;
-            }
+            if(s->machine->common.stf_insn_num_tracing == false){
+              if(stf_trace_trigger(s,GET_PC(),insn)) {
+                s->pc = GET_PC();
+                return insn_executed;
+              }
+            } 
         }
 
     } /* end of main loop */

--- a/include/machine.h
+++ b/include/machine.h
@@ -78,9 +78,9 @@ struct FBDevice {
 #ifdef SIMPOINT_BB
 extern int simpoint_roi;
 
-//#define SIMPOINT_SIZE 1000000UL      // For Benchmarking Fine Grain
+#define SIMPOINT_SIZE 1000000UL      // For Benchmarking Fine Grain
 //#define SIMPOINT_SIZE 10000UL        // For verification
-#define SIMPOINT_SIZE 100000000UL  // Traditional 100M simpoint
+///#define SIMPOINT_SIZE 100000000UL  // Traditional 100M simpoint
 #endif
 
 typedef enum {
@@ -207,6 +207,13 @@ typedef struct VirtMachine {
     uint64_t maxinsns;
     uint64_t trace;
     const char * stf_trace = nullptr; // stf file name
+    uint64_t stf_start = UINT64_MAX;
+    uint64_t stf_length = 0;
+    uint64_t instruction_count = 0;
+    bool     stf_insn_num_tracing;
+    bool     stf_insn_tracing_enabled; // stf tracing is active
+    bool     stf_insn_start;    // detected the START_TRACE opcode
+    bool     stf_insn_stop;     // detected the STOP_TRACE opcode
     bool         stf_tracing_enabled; // stf tracing is active
     bool         stf_no_priv_check;   // override the priv==0 check
     bool         stf_is_start_opc;    // detected the START_TRACE opcode

--- a/include/machine.h
+++ b/include/machine.h
@@ -78,9 +78,9 @@ struct FBDevice {
 #ifdef SIMPOINT_BB
 extern int simpoint_roi;
 
-#define SIMPOINT_SIZE 1000000UL      // For Benchmarking Fine Grain
+//#define SIMPOINT_SIZE 1000000UL      // For Benchmarking Fine Grain
 //#define SIMPOINT_SIZE 10000UL        // For verification
-///#define SIMPOINT_SIZE 100000000UL  // Traditional 100M simpoint
+#define SIMPOINT_SIZE 100000000UL  // Traditional 100M simpoint
 #endif
 
 typedef enum {
@@ -206,6 +206,8 @@ typedef struct VirtMachine {
     char *   terminate_event;
     uint64_t maxinsns;
     uint64_t trace;
+    uint64_t heartbeat;
+    const char * bb_file = nullptr;   // simpoint.bbv file name
     const char * stf_trace = nullptr; // stf file name
     uint64_t stf_start = UINT64_MAX;
     uint64_t stf_length = 0;
@@ -218,6 +220,7 @@ typedef struct VirtMachine {
     bool         stf_no_priv_check;   // override the priv==0 check
     bool         stf_is_start_opc;    // detected the START_TRACE opcode
     bool         stf_is_stop_opc;     // detected the STOP_TRACE opcode
+    bool         stf_exit_on_stop_opc;// terminate the simulation after detecting STOP_TRACE opcode
     uint64_t     stf_prog_asid;       // as named
     uint64_t     stf_count;           // running number of traced insn's
 

--- a/include/machine.h
+++ b/include/machine.h
@@ -75,13 +75,13 @@ struct FBDevice {
 
 #define VM_CONFIG_VERSION 1
 
-#ifdef SIMPOINT_BB
+//#ifdef SIMPOINT_BB
 extern int simpoint_roi;
 
 //#define SIMPOINT_SIZE 1000000UL      // For Benchmarking Fine Grain
 //#define SIMPOINT_SIZE 10000UL        // For verification
-#define SIMPOINT_SIZE 100000000UL  // Traditional 100M simpoint
-#endif
+//#define SIMPOINT_SIZE 100000000UL  // Traditional 100M simpoint
+//#endif
 
 typedef enum {
     VM_FILE_BIOS,
@@ -117,7 +117,7 @@ typedef struct {
     EthernetDevice *net;
 } VMEthEntry;
 
-#ifdef SIMPOINT_BB
+//#ifdef SIMPOINT_BB
 #include <vector>
 struct Simpoint {
     Simpoint(uint64_t i, int j) : start(i), id(j) {}
@@ -126,7 +126,7 @@ struct Simpoint {
     uint64_t start;
     int      id;
 };
-#endif
+//#endif
 
 typedef struct {
     char *           cfg_filename;
@@ -196,10 +196,10 @@ typedef struct VirtMachine {
     /* graphics */
     FBDevice *fb_dev;
 
-#ifdef SIMPOINT_BB
+//#ifdef SIMPOINT_BB
     uint32_t              simpoint_next;
     std::vector<Simpoint> simpoints;
-#endif
+//#endif
 
     char *   snapshot_load_name;
     char *   snapshot_save_name;
@@ -207,6 +207,8 @@ typedef struct VirtMachine {
     uint64_t maxinsns;
     uint64_t trace;
     uint64_t heartbeat;
+    uint64_t simpoint_size;
+    bool     en_bbv = false;// terminate the simulation after detecting STOP_TRACE opcode
     const char * bb_file = nullptr;   // simpoint.bbv file name
     const char * stf_trace = nullptr; // stf file name
     uint64_t stf_start = UINT64_MAX;

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -347,6 +347,10 @@ int main(int argc, char **argv) {
    fprintf(asid_file, "%lx", cpu->satp);
    fflush(asid_file);
 
+   FILE *total_insn_count_file = fopen("total_num_instructions", "w");
+   fprintf(total_insn_count_file, "%lx", total_inst_count);
+   fflush(total_insn_count_file);
+
     double t = get_current_time_in_seconds();
 
     for (int i = 0; i < m->ncpus; ++i) {

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -139,6 +139,7 @@ static int iterate_core(RISCVMachine *m, int hartid, int& n_cycles) {
 
     (void)riscv_read_insn(cpu, &insn_raw, last_pc);
 
+    //fprintf(dromajo_stderr, "\n----Instruction Count-----: %li \n",  m->common.instruction_count);
     if(stf_trace_trigger_insn(cpu, last_pc, m->common.instruction_count)) {
     }
 
@@ -335,12 +336,16 @@ int main(int argc, char **argv) {
             fprintf(dromajo_stderr, "\n\t -- ASID ::  %lx --> %lx @%li \n", prev_prog_asid, (cpu->satp), total_inst_count);
         }
 //#ifdef SIMPOINT_BB
-        if (simpoint_roi & m->common.en_bbv) {
+        if (simpoint_roi && m->common.en_bbv) {
             if (!simpoint_step(m, 0))
                 break;
         }
 //#endif
     } while (keep_going);
+
+   FILE *asid_file = fopen("benchmark_asid", "w");
+   fprintf(asid_file, "%lx", cpu->satp);
+   fflush(asid_file);
 
     double t = get_current_time_in_seconds();
 

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -352,6 +352,7 @@ int main(int argc, char **argv) {
         }
     }
 
+    fprintf(dromajo_stderr, "\nInstruction Count: %i \n", total_inst_count);
     fprintf(dromajo_stderr, "Simulation speed: %5.2f MIPS (single-core)\n",
             1e-6 * *execution_progress_meassure / (t - execution_start_ts));
 

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -49,7 +49,7 @@
 #include "dromajo_stf.h"
 #include <limits>
 
-#ifdef SIMPOINT_BB
+//#ifdef SIMPOINT_BB
 FILE *simpoint_bb_file = nullptr;
 int   simpoint_roi     = 0;  // start without ROI enabled
 
@@ -86,8 +86,8 @@ int simpoint_step(RISCVMachine *m, int hartid) {
     static std::unordered_map<uint64_t, int> pc2id;
     static int                               next_id = 1;
     if (m->common.maxinsns <= next_bbv_dump) {
-        if (m->common.maxinsns > SIMPOINT_SIZE)
-            next_bbv_dump = m->common.maxinsns - SIMPOINT_SIZE;
+        if (m->common.maxinsns > m->common.simpoint_size)
+            next_bbv_dump = m->common.maxinsns - m->common.simpoint_size;
         else
             next_bbv_dump = 0;
 
@@ -122,7 +122,7 @@ int simpoint_step(RISCVMachine *m, int hartid) {
 
     return 1;
 }
-#endif
+//#endif
 
 static int iterate_core(RISCVMachine *m, int hartid, int& n_cycles) {
 
@@ -292,8 +292,8 @@ int main(int argc, char **argv) {
 #else
     RISCVMachine *m = virt_machine_main(argc, argv);
 
-#ifdef SIMPOINT_BB
-    if (m->common.simpoints.empty()) {
+//#ifdef SIMPOINT_BB
+    if (m->common.simpoints.empty() & m->common.en_bbv) {
         if (m->common.bb_file != nullptr){
              simpoint_bb_file = fopen(m->common.bb_file, "w");
         }
@@ -305,7 +305,7 @@ int main(int argc, char **argv) {
             exit(-3);
         }
     }
-#endif
+//#endif
 
     if (!m)
         return 1;
@@ -332,14 +332,14 @@ int main(int argc, char **argv) {
             inst_heart_beat = 0;
         }
         if((cpu->satp) != prev_prog_asid){
-            fprintf(dromajo_stderr, "\t -- ASID ::  %lx --> %lx @%li\n", prev_prog_asid, (cpu->satp), total_inst_count);
+            fprintf(dromajo_stderr, "\n\t -- ASID ::  %lx --> %lx @%li \n", prev_prog_asid, (cpu->satp), total_inst_count);
         }
-#ifdef SIMPOINT_BB
-        if (simpoint_roi) {
+//#ifdef SIMPOINT_BB
+        if (simpoint_roi & m->common.en_bbv) {
             if (!simpoint_step(m, 0))
                 break;
         }
-#endif
+//#endif
     } while (keep_going);
 
     double t = get_current_time_in_seconds();

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -352,7 +352,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    fprintf(dromajo_stderr, "\nInstruction Count: %i \n", total_inst_count);
+    fprintf(dromajo_stderr, "\nInstruction Count: %li \n", total_inst_count);
     fprintf(dromajo_stderr, "Simulation speed: %5.2f MIPS (single-core)\n",
             1e-6 * *execution_progress_meassure / (t - execution_start_ts));
 

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -764,8 +764,10 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
 
             case 'H':
                 heartbeat = (uint64_t)atoll(optarg);
+                break;
             case 'Z':
                 simpoint_size = (uint64_t)atoll(optarg);
+                break;
             case 't':
                 if (trace != UINT64_MAX)
                     usage(prog, "already had a trace set");

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -565,6 +565,9 @@ static void usage(const char *prog, const char *msg) {
             "       --terminate-event name of the validate event to terminate execution\n"
             "       --trace start trace dump after a number of instructions. Trace disabled by default\n"
             "       --stf_trace <filename>  Dump an STF trace to the given file\n"
+            "       --stf_exit_on_stop_opc Terminate the simulation after detecting a STOP_TRACE opcode\n"
+            "       --bb_file <filename>  Name of file to dump simpoint.bb\n"
+            "       --heartbeat <n> after executing every n instructions \n"
             "       --stf_insn_num_tracing  Enable stf tracing with instruction number\n"
             "       --stf_start  starts stf trace after a number of instructions\n"
             "       --stf_length terminates stf trace after a number of instructions from stf_start\n"
@@ -627,7 +630,10 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
     long        ncpus                    = 0;
     uint64_t    maxinsns                 = 0;
     uint64_t    trace                    = UINT64_MAX;
+    uint64_t    heartbeat                = UINT64_MAX;
     const char *stf_trace                = nullptr;
+    bool        stf_exit_on_stop_opc     = false;
+    const char *bb_file	                 = nullptr;
     bool        stf_insn_num_tracing     = false;
     uint64_t    stf_start                = UINT64_MAX;
     uint64_t    stf_length               = 0;
@@ -668,9 +674,12 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
             {"save",                    required_argument, 0,  's' },
             {"simpoint",                required_argument, 0,  'S' },
             {"maxinsns",                required_argument, 0,  'm' }, // CFG
+            {"heartbeat",               required_argument, 0,  'H' }, // CFG
             {"trace",                   required_argument, 0,  't' },
             {"stf_trace",               required_argument, 0,  'z' },
-            {"stf_insn_num_tracing",          no_argument, 0,  'e' },
+            {"stf_exit_on_stop_opc",          no_argument, 0,  'e' },
+            {"bb_file",                 required_argument, 0,  'B' },
+            {"stf_insn_num_tracing",          no_argument, 0,  'E' },
             {"stf_start",               required_argument, 0,  'x' },
             {"stf_length",              required_argument, 0,  'y' },
             {"ignore_sbi_shutdown",     required_argument, 0,  'P' }, // CFG
@@ -747,6 +756,8 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
                 }
                 break;
 
+            case 'H':
+                heartbeat = (uint64_t)atoll(optarg);
             case 't':
                 if (trace != UINT64_MAX)
                     usage(prog, "already had a trace set");
@@ -754,7 +765,9 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
                 break;
 
             case 'z': stf_trace = strdup(optarg); break;
-            case 'e': stf_insn_num_tracing = true; break;
+            case 'e': stf_exit_on_stop_opc = true; break;
+            case 'B': bb_file = strdup(optarg); break;
+            case 'E': stf_insn_num_tracing = true; break;
             case 'x': stf_start = (uint64_t)atoll(optarg); break;
             case 'y': stf_length = (uint64_t)atoll(optarg); break;
             case 'a': stf_no_priv_check = true; break;
@@ -1083,7 +1096,10 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
 
     s->common.snapshot_save_name = snapshot_save_name;
     s->common.trace              = trace;
+    s->common.heartbeat          = heartbeat;
     s->common.stf_trace          = stf_trace;
+    s->common.stf_exit_on_stop_opc  = stf_exit_on_stop_opc;
+    s->common.bb_file            = bb_file;
     s->common.stf_no_priv_check  = stf_no_priv_check;
     s->common.stf_tracing_enabled = false;
     s->common.stf_is_start_opc    = false;

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -567,7 +567,9 @@ static void usage(const char *prog, const char *msg) {
             "       --stf_trace <filename>  Dump an STF trace to the given file\n"
             "       --stf_exit_on_stop_opc Terminate the simulation after detecting a STOP_TRACE opcode\n"
             "       --bb_file <filename>  Name of file to dump simpoint.bb\n"
+            "       --en_bbv Enable bbv collection\n"
             "       --heartbeat <n> after executing every n instructions \n"
+            "       --simpoint_size <n> SIMPOINT_SIZE for bbv collection \n"
             "       --stf_insn_num_tracing  Enable stf tracing with instruction number\n"
             "       --stf_start  starts stf trace after a number of instructions\n"
             "       --stf_length terminates stf trace after a number of instructions from stf_start\n"
@@ -631,8 +633,10 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
     uint64_t    maxinsns                 = 0;
     uint64_t    trace                    = UINT64_MAX;
     uint64_t    heartbeat                = UINT64_MAX;
+    uint64_t    simpoint_size            = 100000000UL;
     const char *stf_trace                = nullptr;
     bool        stf_exit_on_stop_opc     = false;
+    bool        en_bbv                   = false;
     const char *bb_file	                 = nullptr;
     bool        stf_insn_num_tracing     = false;
     uint64_t    stf_start                = UINT64_MAX;
@@ -675,10 +679,12 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
             {"simpoint",                required_argument, 0,  'S' },
             {"maxinsns",                required_argument, 0,  'm' }, // CFG
             {"heartbeat",               required_argument, 0,  'H' }, // CFG
+            {"simpoint_size",           required_argument, 0,  'Z' }, // CFG
             {"trace",                   required_argument, 0,  't' },
             {"stf_trace",               required_argument, 0,  'z' },
             {"stf_exit_on_stop_opc",          no_argument, 0,  'e' },
             {"bb_file",                 required_argument, 0,  'B' },
+            {"en_bbv",                        no_argument, 0,  'v' },
             {"stf_insn_num_tracing",          no_argument, 0,  'E' },
             {"stf_start",               required_argument, 0,  'x' },
             {"stf_length",              required_argument, 0,  'y' },
@@ -758,6 +764,8 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
 
             case 'H':
                 heartbeat = (uint64_t)atoll(optarg);
+            case 'Z':
+                simpoint_size = (uint64_t)atoll(optarg);
             case 't':
                 if (trace != UINT64_MAX)
                     usage(prog, "already had a trace set");
@@ -766,6 +774,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
 
             case 'z': stf_trace = strdup(optarg); break;
             case 'e': stf_exit_on_stop_opc = true; break;
+            case 'v': en_bbv = true; break;
             case 'B': bb_file = strdup(optarg); break;
             case 'E': stf_insn_num_tracing = true; break;
             case 'x': stf_start = (uint64_t)atoll(optarg); break;
@@ -1069,7 +1078,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
         int distance;
         int num;
         while (fscanf(file, "%d %d", &distance, &num) == 2) {
-            uint64_t start = distance * SIMPOINT_SIZE;
+            uint64_t start = distance * s->common.simpoint_size;
 
             if (start == 0) {  // skip boot ROM
                 start = ROM_SIZE;
@@ -1097,9 +1106,11 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
     s->common.snapshot_save_name = snapshot_save_name;
     s->common.trace              = trace;
     s->common.heartbeat          = heartbeat;
+    s->common.simpoint_size      = simpoint_size;
     s->common.stf_trace          = stf_trace;
     s->common.stf_exit_on_stop_opc  = stf_exit_on_stop_opc;
     s->common.bb_file            = bb_file;
+    s->common.en_bbv             = en_bbv;
     s->common.stf_no_priv_check  = stf_no_priv_check;
     s->common.stf_tracing_enabled = false;
     s->common.stf_is_start_opc    = false;

--- a/src/dromajo_stf.cpp
+++ b/src/dromajo_stf.cpp
@@ -61,3 +61,52 @@ bool stf_trace_trigger(RISCVCPUState *s,target_ulong PC,uint32_t insn)
 
     return s->machine->common.stf_tracing_enabled;
 }
+
+#define STF_TRACE_DEBUG	\
+    if(s->machine->common.stf_insn_tracing_enabled){\
+        /**/ fprintf(dromajo_stderr, "\t\t>>>>> Traced Instr Count : %ld / exe:%ld\n", s->machine->common.stf_count, insn_executed); /* */\
+    }
+
+bool stf_trace_trigger_insn(RISCVCPUState *s,target_ulong PC, uint64_t insn_executed) 
+{
+    int hartid = s->mhartid;
+    RISCVCPUState *cpu = s->machine->cpu_state[hartid];
+
+    s->machine->common.stf_insn_start = (insn_executed == s->machine->common.stf_start);
+    s->machine->common.stf_insn_stop  = s->machine->common.stf_insn_tracing_enabled && (s->machine->common.stf_count == s->machine->common.stf_length);//(insn_executed == (s->machine->common.stf_start + s->machine->common.stf_length - 1));
+
+    if(s->machine->common.stf_insn_start) {
+
+        s->machine->common.stf_insn_tracing_enabled = true;
+
+        s->machine->common.stf_prog_asid = (cpu->satp >> 4) & 0xFFFF;
+
+        if((bool)stf_writer == false) {
+            stf_writer.open(s->machine->common.stf_trace);
+            stf_writer.addTraceInfo(stf::TraceInfoRecord(
+                       stf::STF_GEN::STF_GEN_DROMAJO, 1, 1, 0,"Trace from Dromajo"));
+            stf_writer.setISA(stf::ISA::RISCV);
+            stf_writer.setHeaderIEM(stf::INST_IEM::STF_INST_IEM_RV64);
+            stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_RV64);
+            stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_PHYSICAL_ADDRESS);
+            stf_writer.setHeaderPC(PC);
+            stf_writer.finalizeHeader();
+        }
+        fprintf(dromajo_stderr, "\n\t>>> DROMAJO: Tracing Started at 0x%lx @INST_num %ld - asid=%lx\n", PC, insn_executed, s->machine->common.stf_prog_asid);
+        STF_TRACE_DEBUG
+        return true;
+
+    } else if(s->machine->common.stf_insn_stop) {
+
+        s->machine->common.stf_insn_tracing_enabled = false;
+        fprintf(dromajo_stderr, "\n\t>>> DROMAJO: Tracing Stopped at 0x%lx @INST_num %ld\n", PC, insn_executed);
+        fprintf(dromajo_stderr, "\n\t>>> DROMAJO: Traced %ld insts in %ld executed instructions\n",
+                             s->machine->common.stf_count, insn_executed);
+        stf_writer.close();
+        STF_TRACE_DEBUG
+        return false;
+    }
+
+    STF_TRACE_DEBUG
+    return s->machine->common.stf_insn_tracing_enabled;
+}

--- a/src/dromajo_stf.cpp
+++ b/src/dromajo_stf.cpp
@@ -64,7 +64,7 @@ bool stf_trace_trigger(RISCVCPUState *s,target_ulong PC,uint32_t insn)
 
 #define STF_TRACE_DEBUG	\
     if(s->machine->common.stf_insn_tracing_enabled){\
-        /**/ fprintf(dromajo_stderr, "\t\t>>>>> Traced Instr Count : %ld / exe:%ld\n", s->machine->common.stf_count, insn_executed); /* */\
+        /**/ fprintf(dromajo_stderr, "\tSATP: %lx  ASID: %lx>>>>> Traced Instr Count : %ld / exe:%ld\n", cpu->satp, (cpu->satp >> 4) & 0xFFFF, s->machine->common.stf_count, insn_executed); /* */\
     }
 
 bool stf_trace_trigger_insn(RISCVCPUState *s,target_ulong PC, uint64_t insn_executed) 

--- a/src/dromajo_stf.cpp
+++ b/src/dromajo_stf.cpp
@@ -56,6 +56,9 @@ bool stf_trace_trigger(RISCVCPUState *s,target_ulong PC,uint32_t insn)
         fprintf(dromajo_stderr, ">>> DROMAJO: Traced %ld insts\n",
                              s->machine->common.stf_count);
         stf_writer.close();
+        if(s->machine->common.stf_exit_on_stop_opc){
+           s->terminate_simulation = 1;
+        }
         return false;
     }
 
@@ -104,6 +107,9 @@ bool stf_trace_trigger_insn(RISCVCPUState *s,target_ulong PC, uint64_t insn_exec
                              s->machine->common.stf_count, insn_executed);
         stf_writer.close();
         STF_TRACE_DEBUG
+        if(s->machine->common.stf_exit_on_stop_opc){
+           s->terminate_simulation = 1;
+        }
         return false;
     }
 

--- a/src/dromajo_stf.cpp
+++ b/src/dromajo_stf.cpp
@@ -67,7 +67,9 @@ bool stf_trace_trigger(RISCVCPUState *s,target_ulong PC,uint32_t insn)
 
 #define STF_TRACE_DEBUG	\
     if(s->machine->common.stf_insn_tracing_enabled){\
+        if(s->machine->common.stf_count % 1000000 == 0){\
         /**/ fprintf(dromajo_stderr, "\tSATP: %lx  ASID: %lx>>>>> Traced Instr Count : %ld / exe:%ld\n", cpu->satp, (cpu->satp >> 4) & 0xFFFF, s->machine->common.stf_count, insn_executed); /* */\
+        }\
     }
 
 bool stf_trace_trigger_insn(RISCVCPUState *s,target_ulong PC, uint64_t insn_executed) 
@@ -75,8 +77,16 @@ bool stf_trace_trigger_insn(RISCVCPUState *s,target_ulong PC, uint64_t insn_exec
     int hartid = s->mhartid;
     RISCVCPUState *cpu = s->machine->cpu_state[hartid];
 
-    s->machine->common.stf_insn_start = (insn_executed == s->machine->common.stf_start);
-    s->machine->common.stf_insn_stop  = s->machine->common.stf_insn_tracing_enabled && (s->machine->common.stf_count == s->machine->common.stf_length);//(insn_executed == (s->machine->common.stf_start + s->machine->common.stf_length - 1));
+    if((not (s->machine->common.stf_insn_tracing_enabled) ) & (s->machine->common.stf_count == 0)){
+       s->machine->common.stf_insn_start = (insn_executed >= s->machine->common.stf_start);
+    } else {
+       s->machine->common.stf_insn_start = false;
+    }
+    if(s->machine->common.stf_insn_tracing_enabled){
+       s->machine->common.stf_insn_stop  = (s->machine->common.stf_count == s->machine->common.stf_length);
+    } else {
+       s->machine->common.stf_insn_stop  = false;
+    }
 
     if(s->machine->common.stf_insn_start) {
 

--- a/src/riscv_cpu.cpp
+++ b/src/riscv_cpu.cpp
@@ -1893,13 +1893,17 @@ static int csr_write(RISCVCPUState *s, uint32_t funct3, uint32_t csr, target_ulo
             } else if ((val & 1) && simpoint_roi) {
                 fprintf(dromajo_stderr, "simpoint ROI already started\n");
             } else if ((val & 1) == 0 && simpoint_roi) {
+              if(s->machine->common.en_bbv){
                 fprintf(dromajo_stderr, "simpoint ROI finished\n");
+              }
                 simpoint_roi = 0;
             } else if ((val & 1) == 0 && simpoint_roi == 0) {
                 fprintf(dromajo_stderr, "simpoint ROI already finished\n");
             } else {
+              if(s->machine->common.en_bbv){
                 fprintf(dromajo_stderr, "simpoint ROI started\n");
                 simpoint_roi = 1;
+              }
             }
 
             break;

--- a/src/riscv_cpu.cpp
+++ b/src/riscv_cpu.cpp
@@ -1483,9 +1483,9 @@ static int csr_read(RISCVCPUState *s, uint32_t funct3, target_ulong *pval, uint3
         case CSR_PMPADDR(13):
         case CSR_PMPADDR(14):
         case CSR_PMPADDR(15): val = s->csr_pmpaddr[csr - CSR_PMPADDR(0)]; break;
-#ifdef SIMPOINT_BB
+//#ifdef SIMPOINT_BB
         case 0x8C2: val = 0; break;
-#endif
+//#endif
 
         default:
         invalid_csr:
@@ -1881,7 +1881,7 @@ static int csr_write(RISCVCPUState *s, uint32_t funct3, uint32_t csr, target_ulo
         case 0xb1f:
             // Allow, but ignore to write to performance counters mhpmcounter
             break;
-#ifdef SIMPOINT_BB
+//#ifdef SIMPOINT_BB
         case 0x8C2:
             if ((val & 3) == 3) {
                 fprintf(dromajo_stderr, "simpoint adjust maxinsns to %lld\n", (long long)val >> 2);
@@ -1903,7 +1903,7 @@ static int csr_write(RISCVCPUState *s, uint32_t funct3, uint32_t csr, target_ulo
             }
 
             break;
-#endif
+//#endif
 
         default:
 


### PR DESCRIPTION
Updated Dromajo to simplify the tracing for simpoint:
1. providing simpoint_size on command line by --simpoint_size <num>
2. providing bbv_file_name on command line by --bb_file bbv
3. using the same build for bbv and stf (non-bbv) simulations, by removing ifdef SIMPOINT_BB and made it a command line option with --bbv_en
4. heartbeat to check if simulation didnot hang. (default behavior is no heartbeat.) It can be configured with --heartbeat <n>  similar to simpoint_size.
5. converted roi begin, end, terminate to Macros and included them in $BENCHMARKS/spec2k6/support_files/trace_macros.h  to use for bbv instrumentation similar to start_trace/stop_trace